### PR TITLE
`spago bundle-app -t ./public/index.js` コマンド内の半角スペース削除。

### DIFF
--- a/docs/v0.6/en/getting-started/hello-world.md
+++ b/docs/v0.6/en/getting-started/hello-world.md
@@ -49,7 +49,7 @@ bodyComponent = do
 Finally, bundle the application.
 
 ```
-spago bundle-app -t . /public/index.js
+spago bundle-app -t ./public/index.js
 ```
 
 Now, when you open `public/index.html` in your browser, you will see a big Hello World!

--- a/docs/v0.7/en/getting-started/hello-world.md
+++ b/docs/v0.7/en/getting-started/hello-world.md
@@ -49,7 +49,7 @@ bodyComponent = do
 Finally, bundle the application.
 
 ```
-spago bundle-app -t . /public/index.js
+spago bundle-app -t ./public/index.js
 ```
 
 Now, when you open `public/index.html` in your browser, you will see a big Hello World!

--- a/docs/v0.8/en/getting-started/hello-world.md
+++ b/docs/v0.8/en/getting-started/hello-world.md
@@ -49,7 +49,7 @@ bodyComponent = do
 Finally, bundle the application.
 
 ```
-spago bundle-app -t . /public/index.js
+spago bundle-app -t ./public/index.js
 ```
 
 Now, when you open `public/index.html` in your browser, you will see a Hello World!


### PR DESCRIPTION
## 概要

コマンド

`spago bundle-app -t ./public/index.js` 

にあった`.`と `/` の間の半角スペースを取り除きました。

変更前
`. /public/index.js`

変更後
`./public/index.js`

レビューいただけますと幸いです。